### PR TITLE
Added *city_region* functionality to obtain region codes from free geoip...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,41 @@ Example
 
                 set req.http.X-Country-Name = geoip.country_name("127.0.0.1");
 
+client_city_region_name
+-----------------------
+
+Prototype
+        ::
+
+                client_city_region_name()
+Return value
+	STRING
+Description
+	Returns region name string from client IP address using the GeoIPCity.dat database
+Example
+        ::
+
+                set req.http.X-Region-Name = geoip.client_city_region_name();
+
+city_region_name
+------------------------------
+
+Prototype
+        ::
+
+                city_region_name(STRING S)
+Return value
+	STRING
+Description
+	Returns region name string from given IP address using the GeoIPCity.dat database
+Example
+        ::
+
+                set req.http.X-Region-Name = geoip.city_region_name("127.0.0.1");
+
+
+
+
 
 client_region_name (not exported yet)
 -------------------------------------
@@ -186,6 +221,17 @@ Install the GeoIP library headers::
 
  apt-get install libgeoip-dev
 
+If you want to be able to use the city_region_name() and 
+client_city_region_name() functions, you will need to download the 
+GeoIPCity.dat (subscription) or GeoLiteCity.dat (free) databases from
+MaxMind (http://geolite.maxmind.com/download/geoip/database/).
+If you go with GeoLiteCity.dat, be sure to create a simlink named
+GeoIPCity.dat that points to GeoLiteCity.dat in the directory where
+GeoIP.dat resides (typically in /usr/local/share/GeoIP/). If you do
+not install this database, the third unit test will fail but you
+will still be able to use the country code and country name
+functions without a problem.
+
 To check out the current development source::
 
  git clone git://github.com/lampeh/libvmod-geoip.git
@@ -222,8 +268,8 @@ In your VCL you could then use this vmod along the following lines::
 HISTORY
 =======
 
-No history yet.
-
+* Region code functionality based on the GeoIPCity/GeoCityLite databases 
+from MaxMind were contributed by developers from www.dnainfo.com.
 
 COPYRIGHT
 =========

--- a/src/tests/test03.vtc
+++ b/src/tests/test03.vtc
@@ -1,0 +1,22 @@
+varnishtest "Test geoip vmod"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import geoip from "${vmod_topbuild}/src/.libs/libvmod_geoip.so";
+
+	sub vcl_deliver {
+		set resp.http.X-Region = geoip.city_region_name("38.108.216.154");
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.http.X-Region == "NY"
+}
+
+client c1 -run

--- a/src/vmod_geoip.vcc
+++ b/src/vmod_geoip.vcc
@@ -11,6 +11,11 @@ Function STRING country_name(PRIV_VCL, STRING)
 #Function STRING ip_country_name(PRIV_VCL, IP)
 Function STRING client_country_name(PRIV_VCL)
 
+## look up region names via city database
+Function STRING city_region_name(PRIV_VCL, STRING)
+#Function STRING ip_city_region_name(PRIV_VCL, IP)
+Function STRING client_city_region_name(PRIV_VCL)
+
 ## region name functions not enabled yet
 #Function STRING region_name(PRIV_VCL, STRING)
 ##Function STRING ip_region_name(PRIV_VCL, IP)


### PR DESCRIPTION
The basic GeoIP.dat database only includes country codes.
There is a free version of the GeoIPCity.dat database called GeoCityLite.dat that contains city and region codes for ip addresses. There is also a subscription only GeoIPRegion.dat database.

In order to obtain region codes from IP address, I added some functionality to open the appropriate database depending on what you are trying to accomplish. I also added and exposed a couple of functions that will allow you to pull the region codes from the city database.
